### PR TITLE
Upload bundle to API

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,10 @@ async function bundleFunctions(file) {
 }
 
 /**
+ * @typedef {{ sha: string, handlers: string[], content_length: number, content_type: string }} BundleInfo
+ */
+
+/**
  * Writes out the bundled code to disk along with any meta info
  *
  * @param {string} bundle bundled code
@@ -114,8 +118,9 @@ async function writeBundle(bundle, handlers, outputDir, isLocal) {
   const shasum = crypto.createHash("sha1");
   shasum.update(buf);
 
+  /** @type {BundleInfo} */
   const bundleInfo = {
-    shaSum: shasum.digest("hex"),
+    sha: shasum.digest("hex"),
     handlers,
     // needs to have length of the byte representation, not the string length
     content_length: buf.length,

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const nodeResolve = require("@rollup/plugin-node-resolve");
 const makeDir = require("make-dir");
 const rollup = require("rollup");
 const json = require("@rollup/plugin-json");
+const fetch = require("node-fetch");
 
 const babel = nodeBabel.babel;
 const resolve = nodeResolve.nodeResolve;
@@ -16,6 +17,7 @@ const LOCAL_OUT_DIR = path.join(process.cwd(), ".netlify", "edge-handlers");
 const MANIFEST_FILE = "manifest.json";
 const MAIN_FILE = "__netlifyMain.ts";
 const CONTENT_TYPE = "application/javascript";
+const API_HOST = "api.netlify.com";
 
 /**
  * Generates an entrypoint for bundling the handlers
@@ -109,9 +111,10 @@ async function bundleFunctions(file) {
  * @param {string[]} handlers names of the included handlers
  * @param {string} outputDir path to the output directory (created if not exists)
  * @param {boolean} isLocal whether we're running locally or in CI
+ * @param {string | null} apiToken Netlify API token used for uploads
  * @returns {Promise<void>}
  */
-async function writeBundle(bundle, handlers, outputDir, isLocal) {
+async function publishBundle(bundle, handlers, outputDir, isLocal, apiToken) {
   // encode bundle into bytes
   const buf = Buffer.from(bundle, "utf-8");
 
@@ -131,19 +134,77 @@ async function writeBundle(bundle, handlers, outputDir, isLocal) {
     await makeDir(outputDir);
 
     // bundled handlers
-    const outputFile = path.join(outputDir, bundleInfo.shaSum);
+    const outputFile = path.join(outputDir, bundleInfo.sha);
     await fsPromises.writeFile(outputFile, bundle, "utf-8");
 
     // manifest
     const manifestFile = path.join(outputDir, MANIFEST_FILE);
     await fsPromises.writeFile(manifestFile, JSON.stringify(bundleInfo));
+  } else {
+    await uploadBundle(buf, bundleInfo, process.env.DEPLOY_ID, apiToken);
   }
 }
 
+/**
+ *
+ * @param {Buffer} buf UTF-8 encoded handler bundle
+ * @param {BundleInfo} info metadata about the bundle
+ * @param {string} deployId id of the deploy the bundle is deployed for
+ * @param {string} apiToken token for authorizing on the API
+ * @returns {Promise<boolean>} Whether the bundle was newly uploaded (and did not already exist)
+ */
+async function uploadBundle(buf, info, deployId, apiToken) {
+  const resp = await fetch(`https://${API_HOST}/api/v1/deploys/${deployId}/edge_handlers`, {
+    method: "POST",
+    body: JSON.stringify(info),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiToken}`,
+    },
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Invalid status: ${resp.status}`);
+  }
+
+  const { error, exists, upload_url } = await resp.json();
+  if (error) {
+    throw new Error(`Failed to upload: ${error}`);
+  }
+  if (exists) {
+    console.log("Bundle already exists. Skipping upload...");
+    return false;
+  }
+  if (!upload_url) {
+    throw new Error("Missing upload url");
+  }
+
+  await fetch(upload_url, {
+    method: "PUT",
+    body: buf,
+    headers: {
+      "Content-Type": CONTENT_TYPE,
+    },
+  });
+
+  return true;
+}
+
 module.exports = {
-  onPostBuild: async ({ inputs }) => {
+  onPostBuild: async ({ inputs, constants }) => {
     const { mainFile, handlers } = await assemble(inputs.sourceDir);
     const bundle = await bundleFunctions(mainFile);
-    await writeBundle(bundle, handlers, LOCAL_OUT_DIR, true);
+    await publishBundle(bundle, handlers, LOCAL_OUT_DIR, constants.IS_LOCAL, constants.NETLIFY_API_TOKEN);
+  },
+  /**
+   * @type {(deployId: string, apiToken: string) => Promise<boolean>}
+   */
+  deployFromManifest: async (deployId, apiToken) => {
+    const manifestFile = await fsPromises.readFile(path.join(LOCAL_OUT_DIR, MANIFEST_FILE), "utf-8");
+    /** @type {BundleInfo} */
+    const manifest = JSON.parse(manifestFile);
+
+    const bundle = await fsPromises.readFile(path.join(LOCAL_OUT_DIR, manifest.sha));
+    return uploadBundle(bundle, manifest, deployId, apiToken);
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2143,6 +2143,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-releases": {
       "version": "1.1.61",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@types/node": "^14.0.27",
     "make-dir": "^3.1.0",
+    "node-fetch": "^2.6.1",
     "rollup": "^2.23.1",
     "rollup-plugin-esbuild": "^2.4.2",
     "typescript": "^3.9.7"


### PR DESCRIPTION
**Which problem is this pull request solving?**

At some point we'll need to upload the handler bundle to the API.

**List other issues or pull requests related to this problem**

n/a

**Describe the solution you've chosen**

This uploads the bundle when running inside the Netlify build environment.
Uses this api endpoint: https://bitballoon-openapi.netlify.app/#operation/Edge%20Handlers-create

There is also a new special export for triggering an upload of a saved handler manifest.
This can be used for people using the `netlify deploy` command via the CLI.

This is not thoroughly tested, but i think we should do that as we try to get it out into the wild.

@ehmicky is there a better HTTP client i could use?

**Describe alternatives you've considered**

n/a

**Checklist**

- [ ] The status checks are successful (continuous integration). Those can be seen below.
