### PR TITLE
Remove `inputs` from `manifest.yml`

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,3 @@ name: "@netlify/plugin-edge-handlers"
 inputs:
   - name: sourceDir
     default: "edge-handlers"
-  - name: outputDir
-    default: ".netlify/handlers"
-  - name: apiHost
-    default: "api.netlify.com"


### PR DESCRIPTION
The following `inputs` from `manifest.yml` are not used anymore in the code. This is based also on the discussion at https://github.com/netlify/pod-the-builder/issues/51.