### PR TITLE
throw error when dependency is not installed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,11 @@ async function bundleFunctions(file) {
         compact: true,
       }),
     ],
+    onwarn(msg) {
+      if (msg.code == "UNRESOLVED_IMPORT") {
+        throw new Error(`Could not resolve ${msg.source} module. Please install this locally`);
+      }
+    },
   };
 
   const bundle = await rollup.rollup(options);


### PR DESCRIPTION
**Which problem is this pull request solving?**
Currently the plugin bundles even when a dependency is treated as an external one. Given that edge handlers requires dependencies to be inlined, the expected outcome is to throw instead of allow the bundle to generate.

**List other issues or pull requests related to this problem**
Fixes #31 

**Describe the solution you've chosen**
Added a configuration in rollup that checks for warning and throws when dependency is not installed.

**Describe alternatives you've considered**

**Checklist**

Please add a `x` inside each checkbox:

- [x] The status checks are successful (continuous integration). Those can be seen below.
